### PR TITLE
[TP-DISPLAY 9.12.r1] Get Edo displays working

### DIFF
--- a/somc_panel/common.c
+++ b/somc_panel/common.c
@@ -56,7 +56,7 @@ bool somc_panel_vreg_is_enabled(struct dsi_regulator_info *regs,
 	if (!is_invalid)
 		return regulator_is_enabled(vreg.vreg);
 
-	return 0;
+	return false;
 }
 
 int somc_panel_vreg_ctrl(struct dsi_regulator_info *regs,

--- a/somc_panel/dsi_panel_driver.c
+++ b/somc_panel/dsi_panel_driver.c
@@ -1216,12 +1216,12 @@ int dsi_panel_driver_parse_dt(struct dsi_panel *panel,
 	panel_type = of_get_property(np, "somc,dsi-panel-type", NULL);
 	if (!panel_type) {
 		pr_debug("%s:failed parse dsi-panel-type \n", __func__);
-		spec_pdata->oled_disp = false;
-	} else if (!strcmp(panel_type, "oled")) {
 		spec_pdata->oled_disp = true;
+	} else if (!strcmp(panel_type, "lcd")) {
+		spec_pdata->oled_disp = false;
 	} else {
 		pr_err("%s:failed parse dsi-panel-type \n", __func__);
-		spec_pdata->oled_disp = false;
+		spec_pdata->oled_disp = true;
 	}
 
 	rc = of_property_read_u32(np,

--- a/somc_panel/incell.h
+++ b/somc_panel/incell.h
@@ -68,14 +68,7 @@ typedef enum {
  * @return INCELL_OK     : Get power status successfully <br>
  *         INCELL_ERROR  : Failed to get power status.
  */
-#ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
 extern int incell_get_power_status(incell_pw_status *power_status);
-#else
-static inline int incell_get_power_status(incell_pw_status *power_status) {
-		power_status->display_power = INCELL_POWER_ON;
-		power_status->touch_power = INCELL_POWER_ON;
-		return INCELL_OK;}
-#endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
 
 /**
  * @brief Display control mode.
@@ -87,11 +80,7 @@ static inline int incell_get_power_status(incell_pw_status *power_status) {
  *         INCELL_EBUSY     : try lock failed.
  * @attention You cannot call this function from same fb_blank context.
  */
-#ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
 extern int incell_control_mode(incell_intf_mode mode, bool force);
-#else
-static inline int incell_control_mode(incell_intf_mode mode, bool force) {return INCELL_OK;}
-#endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
 
 /**
  * @brief LCD/Touch Power lock control.
@@ -104,58 +93,16 @@ static inline int incell_control_mode(incell_intf_mode mode, bool force) {return
  *         INCELL_ALREADY_LOCKED   : Already power locked <br>
  *         INCELL_ALREADY_UNLOCKED : Already power unlocked.
  */
-#ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
 extern int incell_power_lock_ctrl(incell_pw_lock lock,
 		incell_pw_status *power_status);
-#else
-static inline int incell_power_lock_ctrl(incell_pw_lock lock,
-					 incell_pw_status *power_status) {return INCELL_OK;}
-#endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
-
-#ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
 extern int incell_get_panel_name(void);
-#else
-static inline int incell_get_panel_name(void) {return 0; }
-#endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
-
-#ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
 extern bool incell_get_system_status(void);
-#else
-static inline bool incell_get_system_status(void) {return true; }
-#endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
-
-#ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
 extern int incell_get_display_aod(void);
-#else
-static inline int incell_get_display_aod(void) {return 0; }
-#endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
-
-#ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
 extern int incell_get_display_sod(void);
-#else
-static inline int incell_get_display_sod(void) {return 0; }
-#endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
-
-#ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
 extern int incell_get_display_pre_sod(void);
-#else
-static inline int incell_get_display_pre_sod(void) {return 0; }
-#endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
-
-#ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
 int somc_panel_external_control_touch_power(bool enable);
-#else
-static inline int somc_panel_external_control_touch_power(bool enable)
-{ return 0; }
-#endif
-
-#ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
 bool incell_touch_is_compatible(incell_touch_type type);
-#else
-static inline bool incell_touch_is_compatible(incell_touch_type) {
-	return true;
-}
-#endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
+
 
 #endif /* __INCELL_H__ */
 

--- a/somc_panel/panel_detect.c
+++ b/somc_panel/panel_detect.c
@@ -98,7 +98,10 @@ static inline int single_panel_setup(struct dsi_display *display,
 {
 	struct device_node *this = *node;
 	struct device_node *pan =
-		of_parse_phandle(this, "qcom,dsi-panel", 0);
+		of_parse_phandle(this, "qcom,dsi-default-panel", 0);
+
+	if (!IS_ERR_OR_NULL(display->panel_node))
+		return 0;
 
 	if (pan == NULL) {
 		pr_err("%s: Cannot find phandle to DSI panel!!!\n", __func__);
@@ -121,10 +124,8 @@ int somc_panel_detect(struct dsi_display *display,
 
 	int rc = 0;
 
-	if (of_property_read_bool(*node, "somc,bootloader-panel-detect")) {
-		pr_err("Bootloader gives us the panel name. Nice job!\n");
+	if (!of_property_read_bool(*node, "somc,start-panel-detection"))
 		return single_panel_setup(display, node);
-	};
 
 	if (use_cmd_detect || use_dric_only) {
 		pr_err("Command detection or DrIC detection not yet supported "

--- a/somc_panel/somc_panel_exts.h
+++ b/somc_panel/somc_panel_exts.h
@@ -263,11 +263,13 @@ struct dsi_samsung_hbm {
 #define SHORT_WORKER_PASSIVE		false
 #define SHORT_IRQF_DISABLED		0x00000020
 
-#ifdef CONFIG_ARCH_SONY_SEINE
- #define SHORT_IRQF_FLAGS		(IRQF_ONESHOT | IRQF_TRIGGER_RISING)
-#else
+
+
+#if defined(CONFIG_ARCH_SONY_KUMANO) || defined(CONFIG_ARCH_SONY_TAMA)
  #define SHORT_IRQF_FLAGS		(SHORT_IRQF_DISABLED | IRQF_ONESHOT | \
 					 IRQF_TRIGGER_HIGH | IRQF_TRIGGER_RISING)
+#else
+ #define SHORT_IRQF_FLAGS		(IRQF_ONESHOT | IRQF_TRIGGER_RISING)
 #endif
 struct short_detection_ctrl {
 	struct delayed_work check_work;


### PR DESCRIPTION
This patchset contains changes to get edo platform displays working.

Tested on PDX203: display works.