### PR TITLE
[9.12.r1] Avoid touching optional LUT clock for SDM660

### DIFF
--- a/msm/sde/sde_crtc.c
+++ b/msm/sde/sde_crtc.c
@@ -3831,6 +3831,7 @@ static void sde_crtc_handle_power_event(u32 event_type, void *arg)
 	int ret = 0;
 	struct drm_event event;
 	struct msm_drm_private *priv;
+	struct sde_kms *kms;
 
 	if (!crtc) {
 		SDE_ERROR("invalid crtc\n");
@@ -3839,6 +3840,7 @@ static void sde_crtc_handle_power_event(u32 event_type, void *arg)
 	sde_crtc = to_sde_crtc(crtc);
 	cstate = to_sde_crtc_state(crtc->state);
 	priv = crtc->dev->dev_private;
+	kms = _sde_crtc_get_kms(crtc);
 
 	mutex_lock(&sde_crtc->crtc_lock);
 
@@ -3846,11 +3848,16 @@ static void sde_crtc_handle_power_event(u32 event_type, void *arg)
 
 	switch (event_type) {
 	case SDE_POWER_EVENT_POST_ENABLE:
-		/* disable mdp LUT memory retention */
-		ret = sde_power_clk_set_flags(&priv->phandle, "lut_clk",
-					CLKFLAG_NORETAIN_MEM);
-		if (ret)
-			SDE_ERROR("disable LUT memory retention err %d\n", ret);
+		if (!IS_SDE_MAJOR_MINOR_SAME(kms->catalog->hwversion,
+				SDE_HW_VER_320) &&
+			!IS_SDE_MAJOR_MINOR_SAME(kms->catalog->hwversion,
+				SDE_HW_VER_330)) {
+			/* disable mdp LUT memory retention */
+			ret = sde_power_clk_set_flags(&priv->phandle, "lut_clk",
+						CLKFLAG_NORETAIN_MEM);
+			if (ret)
+				SDE_ERROR("disable LUT memory retention err %d\n", ret);
+		}
 
 		/* restore encoder; crtc will be programmed during commit */
 		drm_for_each_encoder_mask(encoder, crtc->dev,
@@ -3875,11 +3882,16 @@ static void sde_crtc_handle_power_event(u32 event_type, void *arg)
 		sde_cp_crtc_post_ipc(crtc);
 		break;
 	case SDE_POWER_EVENT_PRE_DISABLE:
-		/* enable mdp LUT memory retention */
-		ret = sde_power_clk_set_flags(&priv->phandle, "lut_clk",
-					CLKFLAG_RETAIN_MEM);
-		if (ret)
-			SDE_ERROR("enable LUT memory retention err %d\n", ret);
+		if (!IS_SDE_MAJOR_MINOR_SAME(kms->catalog->hwversion,
+				SDE_HW_VER_320) &&
+			!IS_SDE_MAJOR_MINOR_SAME(kms->catalog->hwversion,
+				SDE_HW_VER_330)) {
+			/* enable mdp LUT memory retention */
+			ret = sde_power_clk_set_flags(&priv->phandle, "lut_clk",
+						CLKFLAG_RETAIN_MEM);
+			if (ret)
+				SDE_ERROR("enable LUT memory retention err %d\n", ret);
+		}
 
 		drm_for_each_encoder_mask(encoder, crtc->dev,
 				crtc->state->encoder_mask) {

--- a/msm/sde/sde_hw_catalog.c
+++ b/msm/sde/sde_hw_catalog.c
@@ -1309,8 +1309,8 @@ static void _sde_sspp_setup_cursor(struct sde_mdss_cfg *sde_cfg,
 	struct sde_sspp_cfg *sspp, struct sde_sspp_sub_blks *sblk,
 	struct sde_prop_value *prop_value, u32 *cursor_count)
 {
-	if (!IS_SDE_MAJOR_MINOR_SAME(sde_cfg->hwversion, SDE_HW_VER_300) ||
-		!IS_SDE_MAJOR_MINOR_SAME(sde_cfg->hwversion, SDE_HW_VER_320) ||
+	if (!IS_SDE_MAJOR_MINOR_SAME(sde_cfg->hwversion, SDE_HW_VER_300) &&
+		!IS_SDE_MAJOR_MINOR_SAME(sde_cfg->hwversion, SDE_HW_VER_320) &&
 		!IS_SDE_MAJOR_MINOR_SAME(sde_cfg->hwversion, SDE_HW_VER_330))
 		SDE_ERROR("invalid sspp type %d, xin id %d\n",
 				sspp->type, sspp->xin_id);


### PR DESCRIPTION
MDP LUT clock is not present on all MDSS revisions, in our case on
SDM660 family SoCs. Hence, avoid setting MDP LUT memory retention
flag to retain/noretain the memory.
This will also prevent useless kernel log spam.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>