### PR TITLE
[9.12.r1] SoMC Tama stabilization

### DIFF
--- a/msm/dsi/dsi_display.c
+++ b/msm/dsi/dsi_display.c
@@ -5238,6 +5238,10 @@ static int dsi_display_bind(struct device *dev,
 		goto error_host_deinit;
 	}
 
+#ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
+	primary_display = display;
+#endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
+
 	DSI_INFO("Successfully bind display panel '%s'\n", display->name);
 	display->drm_dev = drm;
 
@@ -5506,12 +5510,6 @@ int dsi_display_dev_probe(struct platform_device *pdev)
 		if (rc)
 			goto end;
 	}
-
-#ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
-	primary_display = display;
-	pr_notice("%s: Panel Name = %s\n", __func__, display->name);
-#endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
-
 
 	return 0;
 end:

--- a/msm/sde_rsc.c
+++ b/msm/sde_rsc.c
@@ -59,7 +59,7 @@
 /* Primary panel worst case VSYNC expected to be no less than 30fps */
 #define PRIMARY_VBLANK_WORST_CASE_MS 34
 
-#define DEFAULT_PANEL_MIN_V_PREFILL	35
+#define DEFAULT_PANEL_MIN_V_PREFILL	25
 
 static struct sde_rsc_priv *rsc_prv_list[MAX_RSC_COUNT];
 static struct device *rpmh_dev[MAX_RSC_COUNT];


### PR DESCRIPTION
This patch set contains:
- Tama display panels performance improvement.
- Remove support for custom DRM notifier of panel blank/unblank events.

**This patch set depends on the https://github.com/sonyxperiadev/kernel/pull/2479 patch set and must be merged with it.**