### PR TITLE
[9.12.r1] msm: dsi_display: Add hacked param string for bootloader bug

### DIFF
--- a/msm/dsi/dsi_display.c
+++ b/msm/dsi/dsi_display.c
@@ -44,6 +44,7 @@
 #endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
 
 static char dsi_display_primary[MAX_CMDLINE_PARAM_LEN];
+static char dsi_display_primary_hack[MAX_CMDLINE_PARAM_LEN];
 static char dsi_display_secondary[MAX_CMDLINE_PARAM_LEN];
 static struct dsi_display_boot_param boot_displays[MAX_DSI_ACTIVE_DISPLAY] = {
 	{.boot_param = dsi_display_primary},
@@ -2218,6 +2219,10 @@ static void dsi_display_parse_cmdline_topology(struct dsi_display *display,
 		boot_str = dsi_display_primary;
 	else
 		boot_str = dsi_display_secondary;
+
+	if (strlen(dsi_display_primary_hack) > 0 &&
+	    display_type == DSI_PRIMARY)
+		boot_str = dsi_display_primary_hack;
 
 	sw_te = strnstr(boot_str, ":swte", strlen(boot_str));
 	if (sw_te)
@@ -8156,6 +8161,10 @@ static int __init dsi_display_register(void)
 	dsi_phy_drv_register();
 	dsi_ctrl_drv_register();
 
+	if (strlen(dsi_display_primary_hack) > 0)
+		strlcpy(dsi_display_primary, dsi_display_primary_hack,
+			MAX_CMDLINE_PARAM_LEN);
+
 	dsi_display_parse_boot_display_selection();
 
 	return platform_driver_register(&dsi_display_driver);
@@ -8171,6 +8180,10 @@ module_param_string(dsi_display0, dsi_display_primary, MAX_CMDLINE_PARAM_LEN,
 								0600);
 MODULE_PARM_DESC(dsi_display0,
 	"msm_drm.dsi_display0=<display node>:<configX> where <display node> is 'primary dsi display node name' and <configX> where x represents index in the topology list");
+module_param_string(blhack_dsi_display0, dsi_display_primary_hack, MAX_CMDLINE_PARAM_LEN,
+								0600);
+MODULE_PARM_DESC(blhack_dsi_display0,
+	"msm_drm.blhack_dsi_display0=<display node>:<configX> where <display node> is 'primary dsi display node name' and <configX> where x represents index in the topology list");
 module_param_string(dsi_display1, dsi_display_secondary, MAX_CMDLINE_PARAM_LEN,
 								0600);
 MODULE_PARM_DESC(dsi_display1,


### PR DESCRIPTION
The SoMC Kumano bootloader likes to append a string for the panel
that it finds from what it thinks being the right name for it
and with no configuration specified, so, not adhering to the
specification that Qualcomm has put into the driver.

There's only one way to get around it: open a way to hack it...
so, if msm_drm.blhack_dsi_display0 cmdline is detected,
then the msm_drm.dsi_display0 will be totally overridden with
the value in the hacked one.

[Pavel Dubrova]
Adapted for 4.19 kernel. Original commit:
https://github.com/sonyxperiadev/kernel/commit/441ff3ff744b4ff5e40fb6a521f4da9e3e765ede

P.S. I'm not happy with this hack but at the moment we have no choice. After a full bring up of Kumano and Seine platforms, I'll take a look if we have the option to opt out of this hack or not. But for now add this and let's call it a day.