### PR TITLE
[9.12.r1] msm: sde_hw_catalog: Exclude LTM interrupts on Trinket target

### DIFF
--- a/msm/sde/sde_hw_catalog.c
+++ b/msm/sde/sde_hw_catalog.c
@@ -4357,6 +4357,8 @@ static int _sde_hardware_pre_caps(struct sde_mdss_cfg *sde_cfg, uint32_t hw_rev)
 		sde_cfg->sui_block_xin_mask = 0xC61;
 		sde_cfg->has_hdr = false;
 		sde_cfg->has_sui_blendstage = true;
+		clear_bit(MDSS_INTR_LTM_0_INTR, sde_cfg->mdss_irqs);
+		clear_bit(MDSS_INTR_LTM_1_INTR, sde_cfg->mdss_irqs);
 	} else if (IS_BENGAL_TARGET(hw_rev)) {
 		sde_cfg->has_cwb_support = false;
 		sde_cfg->has_qsync = true;


### PR DESCRIPTION
LTM HW block was introduced only in Kona family, hence disable
the unsupported LTM IRQs on Trinket target.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>