### PR TITLE
[9.12.r1] rotator: Remove mdss axi clock for SDE_MDP_HW_REV_500

### DIFF
--- a/rotator/sde_rotator_core.c
+++ b/rotator/sde_rotator_core.c
@@ -3226,8 +3226,10 @@ int sde_rotator_core_init(struct sde_rot_mgr **pmgr,
 			SDE_MDP_HW_REV_500))
 			mgr->max_rot_clk = ROT_R3_MAX_ROT_CLK;
 
-		if (!IS_SDE_MAJOR_SAME(mdata->mdss_version,
-					SDE_MDP_HW_REV_600) &&
+		if (!(IS_SDE_MAJOR_SAME(mdata->mdss_version,
+					SDE_MDP_HW_REV_500) ||
+			IS_SDE_MAJOR_MINOR_SAME(mdata->mdss_version,
+					SDE_MDP_HW_REV_600)) &&
 				!sde_rotator_get_clk(mgr,
 					SDE_ROTATOR_CLK_MDSS_AXI)) {
 			SDEROT_ERR("unable to get mdss_axi_clk\n");


### PR DESCRIPTION
SDE rotator does not need to vote on the mdss axi clock for
SDE_MDP_HW_REV_500. Make changes to check for hw version before
accessing the mdss axi clock.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>