### PR TITLE
[DISPLAY.LA.2.0.r1] msm: Kbuild: Add display root and kernel src paths

### DIFF
--- a/msm/Kbuild
+++ b/msm/Kbuild
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
 KDIR := $(TOP)/kernel_platform/common
+DISPLAY_ROOT=$(srctree)/techpack/display
+KERNEL_SRC=$(srctree)
 
 ifeq ($(CONFIG_ARCH_WAIPIO), y)
 ifeq ($(CONFIG_ARCH_QTI_VM), y)


### PR DESCRIPTION
This is required to build the techpack with our build script.

Signed-off-by: Martin Botka <martin.botka@somainline.org>