### PR TITLE
[9.14] fix dmesg spam on single-dsi platforms

### DIFF
--- a/msm/dsi/dsi_pll_5nm.c
+++ b/msm/dsi/dsi_pll_5nm.c
@@ -492,7 +492,7 @@ static void dsi_pll_config_slave(struct dsi_pll_resource *rsc)
 	rsc->slave = NULL;
 
 	if (!orsc) {
-		pr_warn("slave PLL unavilable, assuming standalone config\n");
+		pr_debug("slave PLL unavailable, assuming standalone config\n");
 		return;
 	}
 


### PR DESCRIPTION
Change pr_warn to pr_debug to avoid extra logging.

Change-Id: I4baf22083005641c77c2ca5a48157d1238b091a2
Signed-off-by: osaisruj <osaisruj@codeaurora.org>