### PR TITLE
[9.14] fix compilation

### DIFF
--- a/msm/sde/sde_hw_dsc_1_2.c
+++ b/msm/sde/sde_hw_dsc_1_2.c
@@ -77,7 +77,7 @@ static int _dsc_calc_ob_max_addr(struct sde_hw_dsc *hw_dsc, int num_ss)
 	return 0;
 }
 
-static inline _dsc_subblk_offset(struct sde_hw_dsc *hw_dsc, int s_id,
+static inline int _dsc_subblk_offset(struct sde_hw_dsc *hw_dsc, int s_id,
 		u32 *idx)
 {
 	const struct sde_dsc_sub_blks *sblk;

--- a/msm/sde/sde_hw_vdc.c
+++ b/msm/sde/sde_hw_vdc.c
@@ -64,7 +64,7 @@
 
 #define VDC_CTL_BLOCK_SIZE         0x300
 
-static inline _vdc_subblk_offset(struct sde_hw_vdc *hw_vdc, int s_id,
+static inline int _vdc_subblk_offset(struct sde_hw_vdc *hw_vdc, int s_id,
 		u32 *idx)
 {
 	int rc = 0;


### PR DESCRIPTION
fix error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]