### PR TITLE
[9.12.r1] SoMC Tama/Akatsuki stabilization

### DIFF
--- a/msm/sde/sde_core_perf.c
+++ b/msm/sde/sde_core_perf.c
@@ -138,7 +138,7 @@ static void _sde_core_perf_calc_doze_suspend(struct drm_crtc *crtc,
 		}
 
 		if (!is_doze_suspend && conn && c_conn)
-			SDE_ERROR("No BW, planes:%x dpms_mode:%d lpmode:%d\n",
+			SDE_DEBUG("No BW, planes:%x dpms_mode:%d lpmode:%d\n",
 				state->plane_mask, c_conn->dpms_mode,
 				sde_connector_get_lp(conn));
 		if (conn && c_conn)

--- a/msm/sde/sde_core_perf.c
+++ b/msm/sde/sde_core_perf.c
@@ -41,6 +41,7 @@ enum sde_perf_mode {
 	SDE_PERF_MODE_NORMAL,
 	SDE_PERF_MODE_MINIMUM,
 	SDE_PERF_MODE_FIXED,
+	SDE_PERF_MODE_MAXIMUM,
 	SDE_PERF_MODE_MAX
 };
 
@@ -193,7 +194,8 @@ static void _sde_core_perf_calc_crtc(struct sde_kms *kms,
 
 	_sde_core_perf_calc_doze_suspend(crtc, state, perf);
 
-	if (!sde_cstate->bw_control) {
+	if (!sde_cstate->bw_control ||
+	    kms->perf.perf_tune.mode == SDE_PERF_MODE_MAXIMUM) {
 		for (i = 0; i < SDE_POWER_HANDLE_DBUS_ID_MAX; i++) {
 			perf->bw_ctl[i] = kms->catalog->perf.max_bw_high *
 					1000ULL;
@@ -1116,7 +1118,8 @@ static ssize_t _sde_core_perf_mode_write(struct file *file,
 
 	if (perf_mode == SDE_PERF_MODE_FIXED) {
 		DRM_INFO("fix performance mode\n");
-	} else if (perf_mode == SDE_PERF_MODE_MINIMUM) {
+	} else if (perf_mode == SDE_PERF_MODE_MINIMUM ||
+		   perf_mode == SDE_PERF_MODE_MAXIMUM) {
 		/* run the driver with max clk and BW vote */
 		perf->perf_tune.min_core_clk = perf->max_core_clk_rate;
 		perf->perf_tune.min_bus_vote =

--- a/msm/sde/sde_core_perf.c
+++ b/msm/sde/sde_core_perf.c
@@ -1315,6 +1315,14 @@ int sde_core_perf_init(struct sde_core_perf *perf,
 		perf->max_core_clk_rate = SDE_PERF_DEFAULT_MAX_CORE_CLK_RATE;
 	}
 
+	if (catalog->perf.default_perf_mode < SDE_PERF_MODE_MAX &&
+	    catalog->perf.default_perf_mode >= 0) {
+		perf->perf_tune.mode = catalog->perf.default_perf_mode;
+		SDE_DEBUG("Set perf mode %d\n", catalog->perf.default_perf_mode);
+	} else {
+		SDE_ERROR("Invalid default SDE perf mode. Ignoring setting\n");
+	}
+
 	return 0;
 
 err:

--- a/msm/sde/sde_encoder_phys_cmd.c
+++ b/msm/sde/sde_encoder_phys_cmd.c
@@ -408,7 +408,9 @@ static void sde_encoder_phys_cmd_cont_splash_mode_set(
 	}
 
 	phys_enc->cached_mode = *adj_mode;
+#ifndef CONFIG_ARCH_SONY_TAMA
 	phys_enc->enable_state = SDE_ENC_ENABLED;
+#endif
 
 	if (!phys_enc->hw_ctl || !phys_enc->hw_pp) {
 		SDE_DEBUG("invalid ctl:%d pp:%d\n",

--- a/msm/sde/sde_hw_catalog.c
+++ b/msm/sde/sde_hw_catalog.c
@@ -149,6 +149,7 @@
 #define DEFAULT_AMORTIZABLE_THRESHOLD		25
 #define DEFAULT_MNOC_PORTS			2
 #define DEFAULT_AXI_BUS_WIDTH			32
+#define DEFAULT_PERF_DEFAULT_MODE		0 // SDE_PERF_MODE_NORMAL
 #define DEFAULT_CPU_MASK			0
 #define DEFAULT_CPU_DMA_LATENCY			PM_QOS_DEFAULT_VALUE
 
@@ -228,6 +229,7 @@ enum {
 	PERF_CPU_MASK,
 	PERF_CPU_DMA_LATENCY,
 	PERF_CPU_IRQ_LATENCY,
+	PERF_DEFAULT_MODE,
 	PERF_PROP_MAX,
 };
 
@@ -553,6 +555,8 @@ static struct sde_prop_type sde_perf_prop[] = {
 			PROP_TYPE_U32},
 	{PERF_CPU_IRQ_LATENCY, "qcom,sde-qos-cpu-irq-latency", false,
 			PROP_TYPE_U32},
+	{PERF_DEFAULT_MODE, "qcom,sde-perf-default-mode",
+			false, PROP_TYPE_U32},
 };
 
 static struct sde_prop_type sde_qos_prop[] = {
@@ -3799,6 +3803,11 @@ static void _sde_perf_parse_dt_cfg_populate(struct sde_mdss_cfg *cfg,
 			PROP_VALUE_ACCESS(prop_value,
 				PERF_AXI_BUS_WIDTH, 0) :
 			DEFAULT_AXI_BUS_WIDTH;
+	cfg->perf.default_perf_mode =
+			prop_exists[PERF_DEFAULT_MODE] ?
+			PROP_VALUE_ACCESS(prop_value,
+				PERF_DEFAULT_MODE, 0) :
+			DEFAULT_PERF_DEFAULT_MODE;
 }
 
 static int _sde_perf_parse_dt_cfg(struct device_node *np,

--- a/msm/sde/sde_hw_catalog.h
+++ b/msm/sde/sde_hw_catalog.h
@@ -1182,6 +1182,7 @@ struct sde_perf_cfg {
 	u32 cpu_irq_latency;
 	u32 axi_bus_width;
 	u32 num_mnoc_ports;
+	u32 default_perf_mode;
 };
 
 /**

--- a/somc_panel/somc_panel_exts.h
+++ b/somc_panel/somc_panel_exts.h
@@ -261,16 +261,9 @@ struct dsi_samsung_hbm {
 
 #define SHORT_WORKER_ACTIVE		true
 #define SHORT_WORKER_PASSIVE		false
-#define SHORT_IRQF_DISABLED		0x00000020
 
+#define SHORT_IRQF_FLAGS		(IRQF_ONESHOT | IRQF_TRIGGER_RISING)
 
-
-#if defined(CONFIG_ARCH_SONY_KUMANO) || defined(CONFIG_ARCH_SONY_TAMA)
- #define SHORT_IRQF_FLAGS		(SHORT_IRQF_DISABLED | IRQF_ONESHOT | \
-					 IRQF_TRIGGER_HIGH | IRQF_TRIGGER_RISING)
-#else
- #define SHORT_IRQF_FLAGS		(IRQF_ONESHOT | IRQF_TRIGGER_RISING)
-#endif
 struct short_detection_ctrl {
 	struct delayed_work check_work;
 	int current_chatter_cnt;


### PR DESCRIPTION
- Fix Akatsuki display suspend/resume issue.
- Fix "3 fps" behavior until the first cycle of turning the display off/on for all Tama devices.