### PR TITLE
[2.0.r1] msm: dsi_panel: Fix dsi_panel_driver_post_power_off() call

### DIFF
--- a/msm/dsi/dsi_panel.c
+++ b/msm/dsi/dsi_panel.c
@@ -5260,10 +5260,6 @@ int dsi_panel_unprepare(struct dsi_panel *panel)
 		goto error;
 	}
 
-#ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
-	rc = dsi_panel_driver_post_power_off(panel);
-#endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
-
 error:
 	mutex_unlock(&panel->panel_lock);
 	return rc;
@@ -5286,6 +5282,11 @@ int dsi_panel_post_unprepare(struct dsi_panel *panel)
 		       panel->name, rc);
 		goto error;
 	}
+
+#ifdef CONFIG_DRM_SDE_SPECIFIC_PANEL
+	rc = dsi_panel_driver_post_power_off(panel);
+#endif /* CONFIG_DRM_SDE_SPECIFIC_PANEL */
+
 error:
 	mutex_unlock(&panel->panel_lock);
 	return rc;


### PR DESCRIPTION
This commit fixes the location of the dsi_panel_driver_post_power_off()
function call within the dsi_panel_post_unprepare() function.
Previously, the call was misplaced, potentially leading to
unexpected behavior.