### PR TITLE
[1.0.r1] Add display support for SoC Blair

### DIFF
--- a/msm/Kbuild
+++ b/msm/Kbuild
@@ -50,6 +50,11 @@ ifeq ($(CONFIG_ARCH_ANORAK), y)
 	LINUX_INC +=	-include $(DISPLAY_ROOT)/config/gki_anorakdispconf.h
 endif
 
+ifeq ($(CONFIG_ARCH_BLAIR), y)
+	include $(DISPLAY_ROOT)/config/gki_holidisp.conf
+	LINUX_INC +=	-include $(DISPLAY_ROOT)/config/gki_holidispconf.h
+endif
+
 LINUX_INC +=	-Iinclude/linux \
 		-Iinclude/linux/drm
 

--- a/msm/msm_gem.c
+++ b/msm/msm_gem.c
@@ -700,10 +700,17 @@ void msm_gem_aspace_domain_attach_detach_update(
 int msm_gem_dumb_create(struct drm_file *file, struct drm_device *dev,
 		struct drm_mode_create_dumb *args)
 {
+	uint32_t flags = MSM_BO_SCANOUT;
+
+	if (dev && dev->dev && dev_is_dma_coherent(dev->dev))
+		flags |= MSM_BO_CACHED;
+	else
+		flags |= MSM_BO_WC;
+
 	args->pitch = align_pitch(args->width, args->bpp);
 	args->size  = PAGE_ALIGN(args->pitch * args->height);
 	return msm_gem_new_handle(dev, file, args->size,
-			MSM_BO_SCANOUT | MSM_BO_CACHED, &args->handle, "dumb");
+			flags, &args->handle, "dumb");
 }
 
 int msm_gem_dumb_map_offset(struct drm_file *file, struct drm_device *dev,

--- a/msm/msm_gem.c
+++ b/msm/msm_gem.c
@@ -730,6 +730,7 @@ fail:
 static void *get_vaddr(struct drm_gem_object *obj, unsigned madv)
 {
 	struct msm_gem_object *msm_obj = to_msm_bo(obj);
+	pgprot_t pg_prot = PAGE_KERNEL;
 	int ret = 0;
 
 	mutex_lock(&msm_obj->lock);
@@ -767,8 +768,11 @@ static void *get_vaddr(struct drm_gem_object *obj, unsigned madv)
 			msm_obj->vaddr =
 				dma_buf_vmap(obj->import_attach->dmabuf);
 		} else {
+			if (obj->dev && obj->dev->dev && !dev_is_dma_coherent(obj->dev->dev))
+				pg_prot = pgprot_writecombine(PAGE_KERNEL);
+
 			msm_obj->vaddr = vmap(pages, obj->size >> PAGE_SHIFT,
-				VM_MAP, PAGE_KERNEL);
+				VM_MAP, pg_prot);
 		}
 
 		if (msm_obj->vaddr == NULL) {

--- a/msm/sde/sde_hw_catalog.c
+++ b/msm/sde/sde_hw_catalog.c
@@ -5180,7 +5180,7 @@ static int _sde_hardware_pre_caps(struct sde_mdss_cfg *sde_cfg, uint32_t hw_rev)
 		sde_cfg->mdss_hw_block_size = 0x158;
 		sde_cfg->has_trusted_vm_support = true;
 		sde_cfg->syscache_supported = true;
-	} else if (IS_HOLI_TARGET(hw_rev)) {
+	} else if (IS_HOLI_TARGET(hw_rev) || IS_BLAIR_TARGET(hw_rev)) {
 		sde_cfg->has_cwb_support = false;
 		sde_cfg->has_qsync = true;
 		sde_cfg->perf.min_prefill_lines = 24;

--- a/msm/sde/sde_hw_catalog.h
+++ b/msm/sde/sde_hw_catalog.h
@@ -47,6 +47,7 @@
 #define SDE_HW_VER_650	SDE_HW_VER(6, 5, 0) /* scuba */
 #define SDE_HW_VER_660	SDE_HW_VER(6, 6, 0) /* holi */
 #define SDE_HW_VER_670	SDE_HW_VER(6, 7, 0) /* shima */
+#define SDE_HW_VER_690	SDE_HW_VER(6, 9, 0) /* blair */
 #define SDE_HW_VER_700	SDE_HW_VER(7, 0, 0) /* lahaina */
 #define SDE_HW_VER_720	SDE_HW_VER(7, 2, 0) /* yupik */
 #define SDE_HW_VER_810	SDE_HW_VER(8, 1, 0) /* waipio */
@@ -78,6 +79,7 @@
 #define IS_SCUBA_TARGET(rev) IS_SDE_MAJOR_MINOR_SAME((rev), SDE_HW_VER_650)
 #define IS_HOLI_TARGET(rev) IS_SDE_MAJOR_MINOR_SAME((rev), SDE_HW_VER_660)
 #define IS_SHIMA_TARGET(rev) IS_SDE_MAJOR_MINOR_SAME((rev), SDE_HW_VER_670)
+#define IS_BLAIR_TARGET(rev) IS_SDE_MAJOR_MINOR_SAME((rev), SDE_HW_VER_690)
 #define IS_LAHAINA_TARGET(rev) IS_SDE_MAJOR_MINOR_SAME((rev), SDE_HW_VER_700)
 #define IS_YUPIK_TARGET(rev) IS_SDE_MAJOR_MINOR_SAME((rev), SDE_HW_VER_720)
 #define IS_WAIPIO_TARGET(rev) IS_SDE_MAJOR_MINOR_SAME((rev), SDE_HW_VER_810)

--- a/rotator/sde_rotator_base.h
+++ b/rotator/sde_rotator_base.h
@@ -48,6 +48,7 @@
 #define SDE_MDP_HW_REV_600	SDE_MDP_REV(6, 0, 0)    /* msmnile+ v1.0 */
 #define SDE_MDP_HW_REV_630	SDE_MDP_REV(6, 3, 0)	/* bengal v1.0 */
 #define SDE_MDP_HW_REV_660	SDE_MDP_REV(6, 6, 0)	/* holi */
+#define SDE_MDP_HW_REV_690	SDE_MDP_REV(6, 9, 0)	/* blair */
 #define SDE_MDP_HW_REV_860	SDE_MDP_REV(8, 6, 0)	/* Ravelin */
 
 #define SDE_MDP_VBIF_4_LEVEL_REMAPPER	4

--- a/rotator/sde_rotator_r3.c
+++ b/rotator/sde_rotator_r3.c
@@ -3628,7 +3628,8 @@ static int sde_rotator_hw_rev_init(struct sde_hw_rotator *rot)
 		rot->downscale_caps =
 			"LINEAR/1.5/2/4/8/16/32/64 TILE/1.5/2/4 TP10/1.5/2";
 	} else if (IS_SDE_MAJOR_MINOR_SAME(mdata->mdss_version,
-				SDE_MDP_HW_REV_660)) {
+				SDE_MDP_HW_REV_660) || IS_SDE_MAJOR_MINOR_SAME(
+				mdata->mdss_version, SDE_MDP_HW_REV_690)) {
 		SDEROT_DBG("Sys cache inline rotation not supported\n");
 		set_bit(SDE_CAPS_PARTIALWR,  mdata->sde_caps_map);
 		set_bit(SDE_CAPS_HW_TIMESTAMP, mdata->sde_caps_map);


### PR DESCRIPTION
This patch set brings up display support for SoC Blair.

SoC Blair does not support DMA coherency, so additional checks
were added before performing memory operations.
The display works flawlessly. There are no artifacts in recovery,
suspend/resume works.